### PR TITLE
Initial Setup and README template

### DIFF
--- a/Dishcovery/Dishcovery.xcodeproj/project.pbxproj
+++ b/Dishcovery/Dishcovery.xcodeproj/project.pbxproj
@@ -1,0 +1,559 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXContainerItemProxy section */
+		C08F6E102D4ED4370029D99F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C08F6DF72D4ED4360029D99F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C08F6DFE2D4ED4360029D99F;
+			remoteInfo = Dishcovery;
+		};
+		C08F6E1A2D4ED4370029D99F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C08F6DF72D4ED4360029D99F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C08F6DFE2D4ED4360029D99F;
+			remoteInfo = Dishcovery;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		C08F6DFF2D4ED4360029D99F /* Dishcovery.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Dishcovery.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C08F6E0F2D4ED4370029D99F /* DishcoveryTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DishcoveryTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C08F6E192D4ED4370029D99F /* DishcoveryUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DishcoveryUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		C08F6E012D4ED4360029D99F /* Dishcovery */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Dishcovery;
+			sourceTree = "<group>";
+		};
+		C08F6E122D4ED4370029D99F /* DishcoveryTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = DishcoveryTests;
+			sourceTree = "<group>";
+		};
+		C08F6E1C2D4ED4370029D99F /* DishcoveryUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = DishcoveryUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		C08F6DFC2D4ED4360029D99F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C08F6E0C2D4ED4370029D99F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C08F6E162D4ED4370029D99F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		C08F6DF62D4ED4360029D99F = {
+			isa = PBXGroup;
+			children = (
+				C08F6E012D4ED4360029D99F /* Dishcovery */,
+				C08F6E122D4ED4370029D99F /* DishcoveryTests */,
+				C08F6E1C2D4ED4370029D99F /* DishcoveryUITests */,
+				C08F6E002D4ED4360029D99F /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		C08F6E002D4ED4360029D99F /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				C08F6DFF2D4ED4360029D99F /* Dishcovery.app */,
+				C08F6E0F2D4ED4370029D99F /* DishcoveryTests.xctest */,
+				C08F6E192D4ED4370029D99F /* DishcoveryUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		C08F6DFE2D4ED4360029D99F /* Dishcovery */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C08F6E232D4ED4370029D99F /* Build configuration list for PBXNativeTarget "Dishcovery" */;
+			buildPhases = (
+				C08F6DFB2D4ED4360029D99F /* Sources */,
+				C08F6DFC2D4ED4360029D99F /* Frameworks */,
+				C08F6DFD2D4ED4360029D99F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				C08F6E012D4ED4360029D99F /* Dishcovery */,
+			);
+			name = Dishcovery;
+			packageProductDependencies = (
+			);
+			productName = Dishcovery;
+			productReference = C08F6DFF2D4ED4360029D99F /* Dishcovery.app */;
+			productType = "com.apple.product-type.application";
+		};
+		C08F6E0E2D4ED4370029D99F /* DishcoveryTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C08F6E262D4ED4370029D99F /* Build configuration list for PBXNativeTarget "DishcoveryTests" */;
+			buildPhases = (
+				C08F6E0B2D4ED4370029D99F /* Sources */,
+				C08F6E0C2D4ED4370029D99F /* Frameworks */,
+				C08F6E0D2D4ED4370029D99F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C08F6E112D4ED4370029D99F /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				C08F6E122D4ED4370029D99F /* DishcoveryTests */,
+			);
+			name = DishcoveryTests;
+			packageProductDependencies = (
+			);
+			productName = DishcoveryTests;
+			productReference = C08F6E0F2D4ED4370029D99F /* DishcoveryTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		C08F6E182D4ED4370029D99F /* DishcoveryUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C08F6E292D4ED4370029D99F /* Build configuration list for PBXNativeTarget "DishcoveryUITests" */;
+			buildPhases = (
+				C08F6E152D4ED4370029D99F /* Sources */,
+				C08F6E162D4ED4370029D99F /* Frameworks */,
+				C08F6E172D4ED4370029D99F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C08F6E1B2D4ED4370029D99F /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				C08F6E1C2D4ED4370029D99F /* DishcoveryUITests */,
+			);
+			name = DishcoveryUITests;
+			packageProductDependencies = (
+			);
+			productName = DishcoveryUITests;
+			productReference = C08F6E192D4ED4370029D99F /* DishcoveryUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		C08F6DF72D4ED4360029D99F /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1600;
+				LastUpgradeCheck = 1600;
+				TargetAttributes = {
+					C08F6DFE2D4ED4360029D99F = {
+						CreatedOnToolsVersion = 16.0;
+					};
+					C08F6E0E2D4ED4370029D99F = {
+						CreatedOnToolsVersion = 16.0;
+						TestTargetID = C08F6DFE2D4ED4360029D99F;
+					};
+					C08F6E182D4ED4370029D99F = {
+						CreatedOnToolsVersion = 16.0;
+						TestTargetID = C08F6DFE2D4ED4360029D99F;
+					};
+				};
+			};
+			buildConfigurationList = C08F6DFA2D4ED4360029D99F /* Build configuration list for PBXProject "Dishcovery" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = C08F6DF62D4ED4360029D99F;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = C08F6E002D4ED4360029D99F /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				C08F6DFE2D4ED4360029D99F /* Dishcovery */,
+				C08F6E0E2D4ED4370029D99F /* DishcoveryTests */,
+				C08F6E182D4ED4370029D99F /* DishcoveryUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		C08F6DFD2D4ED4360029D99F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C08F6E0D2D4ED4370029D99F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C08F6E172D4ED4370029D99F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		C08F6DFB2D4ED4360029D99F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C08F6E0B2D4ED4370029D99F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C08F6E152D4ED4370029D99F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		C08F6E112D4ED4370029D99F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C08F6DFE2D4ED4360029D99F /* Dishcovery */;
+			targetProxy = C08F6E102D4ED4370029D99F /* PBXContainerItemProxy */;
+		};
+		C08F6E1B2D4ED4370029D99F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C08F6DFE2D4ED4360029D99F /* Dishcovery */;
+			targetProxy = C08F6E1A2D4ED4370029D99F /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		C08F6E212D4ED4370029D99F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		C08F6E222D4ED4370029D99F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		C08F6E242D4ED4370029D99F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Dishcovery/Preview Content\"";
+				DEVELOPMENT_TEAM = 3JD95QF56H;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bradcooley.Dishcovery;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		C08F6E252D4ED4370029D99F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Dishcovery/Preview Content\"";
+				DEVELOPMENT_TEAM = 3JD95QF56H;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bradcooley.Dishcovery;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		C08F6E272D4ED4370029D99F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bradcooley.DishcoveryTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Dishcovery.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Dishcovery";
+			};
+			name = Debug;
+		};
+		C08F6E282D4ED4370029D99F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bradcooley.DishcoveryTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Dishcovery.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Dishcovery";
+			};
+			name = Release;
+		};
+		C08F6E2A2D4ED4370029D99F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bradcooley.DishcoveryUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Dishcovery;
+			};
+			name = Debug;
+		};
+		C08F6E2B2D4ED4370029D99F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bradcooley.DishcoveryUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Dishcovery;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		C08F6DFA2D4ED4360029D99F /* Build configuration list for PBXProject "Dishcovery" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C08F6E212D4ED4370029D99F /* Debug */,
+				C08F6E222D4ED4370029D99F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C08F6E232D4ED4370029D99F /* Build configuration list for PBXNativeTarget "Dishcovery" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C08F6E242D4ED4370029D99F /* Debug */,
+				C08F6E252D4ED4370029D99F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C08F6E262D4ED4370029D99F /* Build configuration list for PBXNativeTarget "DishcoveryTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C08F6E272D4ED4370029D99F /* Debug */,
+				C08F6E282D4ED4370029D99F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C08F6E292D4ED4370029D99F /* Build configuration list for PBXNativeTarget "DishcoveryUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C08F6E2A2D4ED4370029D99F /* Debug */,
+				C08F6E2B2D4ED4370029D99F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = C08F6DF72D4ED4360029D99F /* Project object */;
+}

--- a/Dishcovery/Dishcovery.xcodeproj/project.pbxproj
+++ b/Dishcovery/Dishcovery.xcodeproj/project.pbxproj
@@ -399,11 +399,14 @@
 				DEVELOPMENT_TEAM = 3JD95QF56H;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = Dishcovery;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UIStatusBarHidden = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -411,9 +414,13 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bradcooley.Dishcovery;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -428,11 +435,14 @@
 				DEVELOPMENT_TEAM = 3JD95QF56H;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = Dishcovery;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UIStatusBarHidden = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -440,9 +450,13 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bradcooley.Dishcovery;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};

--- a/Dishcovery/Dishcovery.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Dishcovery/Dishcovery.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Dishcovery/Dishcovery/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Dishcovery/Dishcovery/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Dishcovery/Dishcovery/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Dishcovery/Dishcovery/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Dishcovery/Dishcovery/Assets.xcassets/Contents.json
+++ b/Dishcovery/Dishcovery/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Dishcovery/Dishcovery/DishcoveryApp.swift
+++ b/Dishcovery/Dishcovery/DishcoveryApp.swift
@@ -1,0 +1,17 @@
+//
+//  DishcoveryApp.swift
+//  Dishcovery
+//
+//  Created by Brad Cooley on 2/1/25.
+//
+
+import SwiftUI
+
+@main
+struct DishcoveryApp: App {
+    var body: some Scene {
+        WindowGroup {
+          RecipeView()
+        }
+    }
+}

--- a/Dishcovery/Dishcovery/Models/Recipe.swift
+++ b/Dishcovery/Dishcovery/Models/Recipe.swift
@@ -1,0 +1,8 @@
+//
+//  Recipe.swift
+//  Dishcovery
+//
+//  Created by Brad Cooley on 2/1/25.
+//
+
+struct Recipe { }

--- a/Dishcovery/Dishcovery/Persistence/ImageCache.swift
+++ b/Dishcovery/Dishcovery/Persistence/ImageCache.swift
@@ -1,0 +1,8 @@
+//
+//  ImageCache.swift
+//  Dishcovery
+//
+//  Created by Brad Cooley on 2/1/25.
+//
+
+class ImageCache { }

--- a/Dishcovery/Dishcovery/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Dishcovery/Dishcovery/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Dishcovery/Dishcovery/Services/APIService.swift
+++ b/Dishcovery/Dishcovery/Services/APIService.swift
@@ -1,0 +1,15 @@
+//
+//  APIService.swift
+//  Dishcovery
+//
+//  Created by Brad Cooley on 2/1/25.
+//
+
+import Foundation
+
+final class APIService: APIServiceProtocol {
+
+  func fetchRecipies() async -> [Recipe] {
+    return []
+  }
+}

--- a/Dishcovery/Dishcovery/Services/APIServiceProtocol.swift
+++ b/Dishcovery/Dishcovery/Services/APIServiceProtocol.swift
@@ -1,0 +1,10 @@
+//
+//  APIServiceProtocol.swift
+//  Dishcovery
+//
+//  Created by Brad Cooley on 2/1/25.
+//
+
+protocol APIServiceProtocol {
+  func fetchRecipies() async -> [Recipe]
+}

--- a/Dishcovery/Dishcovery/ViewModels/RecipeViewModel.swift
+++ b/Dishcovery/Dishcovery/ViewModels/RecipeViewModel.swift
@@ -1,0 +1,11 @@
+//
+//  RecipeViewModel.swift
+//  Dishcovery
+//
+//  Created by Brad Cooley on 2/1/25.
+//
+
+import Foundation
+
+@MainActor
+class RecipeViewModel: ObservableObject { }

--- a/Dishcovery/Dishcovery/Views/RecipeView.swift
+++ b/Dishcovery/Dishcovery/Views/RecipeView.swift
@@ -1,0 +1,19 @@
+//
+//  RecipeView.swift
+//  Dishcovery
+//
+//  Created by Brad Cooley on 2/1/25.
+//
+
+import SwiftUI
+
+struct RecipeView: View {
+
+  var body: some View {
+    Text("Hello world!")
+  }
+}
+
+#Preview {
+  RecipeView()
+}

--- a/Dishcovery/DishcoveryTests/DishcoveryTests.swift
+++ b/Dishcovery/DishcoveryTests/DishcoveryTests.swift
@@ -1,0 +1,36 @@
+//
+//  DishcoveryTests.swift
+//  DishcoveryTests
+//
+//  Created by Brad Cooley on 2/1/25.
+//
+
+import XCTest
+@testable import Dishcovery
+
+final class DishcoveryTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/Dishcovery/DishcoveryUITests/DishcoveryUITests.swift
+++ b/Dishcovery/DishcoveryUITests/DishcoveryUITests.swift
@@ -1,0 +1,43 @@
+//
+//  DishcoveryUITests.swift
+//  DishcoveryUITests
+//
+//  Created by Brad Cooley on 2/1/25.
+//
+
+import XCTest
+
+final class DishcoveryUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    @MainActor
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    @MainActor
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/Dishcovery/DishcoveryUITests/DishcoveryUITestsLaunchTests.swift
+++ b/Dishcovery/DishcoveryUITests/DishcoveryUITestsLaunchTests.swift
@@ -1,0 +1,33 @@
+//
+//  DishcoveryUITestsLaunchTests.swift
+//  DishcoveryUITests
+//
+//  Created by Brad Cooley on 2/1/25.
+//
+
+import XCTest
+
+final class DishcoveryUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# TakeHome
-Take Home assessment for iOS Engineer Role
+# Dishcovery
+_Take Home assessment for iOS Engineer Role_
+
+### Summary: Include screen shots or a video of your app highlighting its features
+
+### Focus Areas: What specific areas of the project did you prioritize? Why did you choose to focus on these areas?
+
+### Time Spent: Approximately how long did you spend working on this project? How did you allocate your time?
+
+### Trade-offs and Decisions: Did you make any significant trade-offs in your approach?
+
+### Weakest Part of the Project: What do you think is the weakest part of your project?
+
+### Additional Information: Is there anything else we should know? Feel free to share any insights or constraints you encountered.
+


### PR DESCRIPTION
## What is this?
This PR contains the initial setup of the Xcode project along with the README template, as outlined [here](https://d3jbb8n5wk0qxi.cloudfront.net/take-home-project.html#toc_5).

## What's included?
This PR includes:
- Setup of Xcode project
- Updated README to match the template as outlined in the project spec
- Rough scaffolding of MVVM + Repository/Service architecture[^1]
 
## Overall Testing
- [ ] Open Xcode
- [ ] Build the project
- [ ] Run the project on any simulator running iOS 16.1+[^2]
- [ ] Ensure you see "Hello world!" in the middle of the screen

## Testing Images
| Light Appearance | Dark Appearance |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/ace97ac1-0b52-46de-8b4a-ee4e7d91edea" alt="Light Appearance" width="200"/> | <img src="https://github.com/user-attachments/assets/fc5977a8-b2e4-471f-ab56-531a6c29caf5" alt="Dark Appearance" width="200"/> |

[^1]: The app seems small enough that MVVM _should_ be sufficient for both its current and potential future state. I’ve decided to incorporate a repository/service layer because I've learned from my past experiences about letting MVVM evolve into MVMVM (Model-View-Massive-ViewModel). While it makes the architecture a bit more complicated initially (and the app might never fully grow into the architecture), it's better to have it now than to spend time dismantling the ViewModel later (or worse, just accepting that technical debt and living in MVMVM).
[^2]: I chose 16.1 for my target because I know I will want to use `.fontDesign` within SwiftUI, and 16.1 is the lowest target for that capability.